### PR TITLE
phy_tesla.c: Fix compilation errors for TESLA PHYs

### DIFF
--- a/src/phy/phy_tesla.c
+++ b/src/phy/phy_tesla.c
@@ -11,6 +11,8 @@
 #include "phy_base.h"
 #include "phy_family.h"
 
+#include "h2pcs1g.h"  // MAC_IF_EXTERNAL
+
 #define PHY_DEBUG (0)
 
 #if VTSS_TESLA
@@ -1062,7 +1064,7 @@ static vtss_rc vtss_phy_rd_wr_masked(BOOL                 read,
 
 /* Write PHY register */
 // See comment at the do_page_chk
-vtss_rc vtss_phy_wr_page(const vtss_port_no_t port_no,
+static vtss_rc vtss_phy_wr_page(const vtss_port_no_t port_no,
                          const u16            page,
                          const u32            addr,
                          const u16            value)
@@ -1545,7 +1547,9 @@ vtss_rc tesla_init_seq(
     vtss_port_no_t          port_no,
     phy_id_t                *phy_id
 ) {
-    return atom12_init_seq(port_no, phy_id);
+	  // This only does something for revision A, so try to get away without it
+    // return atom12_init_seq(port_no, phy_id);
+		return VTSS_RC_OK;
 }
 
 
@@ -1691,20 +1695,6 @@ vtss_rc tesla_mac_media_if_setup (
 
     return VTSS_RC_OK;
 }
-
-
-vtss_rc tesla_read_temp_reg(
-    vtss_port_no_t  port_no,
-    ushort          *temp
-)
-{
-#if PHY_DEBUG
-    println_str("tesla_read_temp_reg");
-#endif
-    *temp = vtss_phy_read_temp(port_no);
-    return VTSS_RC_OK;
-}
-
 
 #endif // TESLA
 

--- a/src/phy/phydrv.c
+++ b/src/phy/phydrv.c
@@ -456,11 +456,13 @@ void phy_page_std (vtss_port_no_t port_no) {
 void phy_page_ext (vtss_port_no_t port_no) {
     phy_write(port_no, 31, 1);
 }
+#endif  // VTSS_ATOM12_B || VTSS_ATOM12_C || VTSS_ATOM12_D || VTSS_TESLA
 
+#if VTSS_ATOM12_B || VTSS_ATOM12_C || VTSS_ATOM12_D
 void phy_page_ext2 (vtss_port_no_t port_no) {
     phy_write(port_no, 31, 2);
 }
-#endif  // VTSS_ATOM12_B || VTSS_ATOM12_C || VTSS_ATOM12_D || VTSS_TESLA
+#endif // VTSS_ATOM12_B || VTSS_ATOM12_C || VTSS_ATOM12_D
 
 #if VTSS_QUATTRO || VTSS_SPYDER || VTSS_ELISE || VTSS_TESLA || VTSS_ATOM12
 void phy_page_gp (vtss_port_no_t port_no) {

--- a/src/phy/phytsk.c
+++ b/src/phy/phytsk.c
@@ -194,7 +194,8 @@ static vtss_rc vtss_phy_rd_wr_masked(BOOL                 read,
 
     return rc;
 }
-vtss_rc vtss_phy_wr_page(const vtss_port_no_t port_no,
+
+static vtss_rc vtss_phy_wr_page(const vtss_port_no_t port_no,
                          const u16            page,
                          const u32            addr,
                          const u16            value)


### PR DESCRIPTION
Fix missing headers and methods that aren't critical. Undefined symbols, doubly defined methods, defined but unused symbols.